### PR TITLE
Add separation of tracks and ignore tracks made of a single point.

### DIFF
--- a/index.js
+++ b/index.js
@@ -176,13 +176,32 @@ const parseReadStream$1 = /* async */ (readStream) => {
 
     const promiseBody = (resolve, reject) => {
 
+        const object = {
+            'type': 'FeatureCollection',
+            'features': [],
+        };
+
+        const features = object['features'];
+
         let feature, timesArray, coordinatesArray;
 
         let firstChunk = true;
 
         const buffer = Buffer.alloc(SIZE_UPPER);
 
+        const flushFeature = () => {
+
+            if (feature && coordinatesArray.length > 1) {
+
+                features.push(feature);
+
+            }
+
+        };
+
         const handleCreateFeature = () => {
+
+            flushFeature();
 
             const name = Parser.chunkName(buffer);
             const time = Parser.chunkTime(buffer);
@@ -278,6 +297,10 @@ const parseReadStream$1 = /* async */ (readStream) => {
 
                 sizePartialChunk = 0;
 
+                const trackStart = Parser.isTrackStart(buffer);
+
+                firstChunk = firstChunk || trackStart;
+
                 if (firstChunk) {
 
                     firstChunk = false;
@@ -315,10 +338,7 @@ const parseReadStream$1 = /* async */ (readStream) => {
 
         readStream.once('end', () => {
 
-            const object = {
-                'type': 'FeatureCollection',
-                'features': [feature],
-            };
+            flushFeature();
 
             resolve(object);
 


### PR DESCRIPTION
Previously, I had decided to simple merge all points into one big track because, when separating them into other tracks, lonely points would appear. The GeoJSON format requires that a LineString must consist of at least two points. This time, however, I have opted to simply remove tracks that are made of a single point.

The code is now better, and probably more close to what you (webjay) intends it to be, but it still has another small bug: two points far away from the place appear on the rendered map. I have no leads on what causes this.

There's more into the SBP file format. Maybe some chunks in the 32-bytes array have a special purpose, and are not points, but other kind of metadata I'm attaching some screenshots to highlight the points I have raised here.

![screenshot-001](https://user-images.githubusercontent.com/11416855/123351236-af38a580-d52a-11eb-8d08-147dccd9bcd9.png)
![screenshot-002](https://user-images.githubusercontent.com/11416855/123351241-afd13c00-d52a-11eb-9964-12ca536b7668.png)
![screenshot-003](https://user-images.githubusercontent.com/11416855/123351242-b1026900-d52a-11eb-9546-4d8499a55c24.png)
![screenshot-004](https://user-images.githubusercontent.com/11416855/123351246-b19aff80-d52a-11eb-96fb-f3444239ba2f.png)
![screenshot-005](https://user-images.githubusercontent.com/11416855/123351248-b2339600-d52a-11eb-9172-d141eeaf38a9.png)